### PR TITLE
fix(scf): repoint Mode-A crosswalk deps to @auditlogic (iec/iso-42001/nist-csf/us_ny)

### DIFF
--- a/package/scf/scf/2025_2_1_iec_60601_2021/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_iec_60601_2021/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-dev.0",
-  "branch": "dev",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-crosswalk-modea-dep-align",
   "sourceHash": "723c082b9642a8508ac4dc74ccce6b7fc97842aed05885046c635e230ac62d3e",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_iec_60601_2021/package.json
+++ b/package/scf/scf/2025_2_1_iec_60601_2021/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_iec_60601_2021",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for iec_60601_2021_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@zerobias-org/framework-iec-60601-2021": "latest"
+    "@auditlogic/framework-iec-60601-2021": "latest"
   }
 }

--- a/package/scf/scf/2025_2_1_iso_42001_2023/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_iso_42001_2023/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-dev.0",
-  "branch": "dev",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-crosswalk-modea-dep-align",
   "sourceHash": "ee5adef6a7644b834a087c22fc35825c4138d5e429c20b74748afdcce9e6f2be",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_iso_42001_2023/package.json
+++ b/package/scf/scf/2025_2_1_iso_42001_2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_iso_42001_2023",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for iso_42001_2023_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@zerobias-org/framework-iso-42001-2023": "latest"
+    "@auditlogic/framework-iso-42001-2023": "latest"
   }
 }

--- a/package/scf/scf/2025_2_1_nist_csf_v2/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_nist_csf_v2/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-dev.0",
-  "branch": "dev",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-crosswalk-modea-dep-align",
   "sourceHash": "91d0929caae0bbf01fe1b5d75329cc8094e314e207784f3a5eefbe609012e230",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_nist_csf_v2/package.json
+++ b/package/scf/scf/2025_2_1_nist_csf_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_nist_csf_v2",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for nist_csf_v2_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@zerobias-org/framework-nist-csf-v2": "latest"
+    "@auditlogic/framework-nist-csf-v2": "latest"
   }
 }

--- a/package/scf/scf/2025_2_1_us_ny_dfs_2023/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_us_ny_dfs_2023/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-dev.0",
-  "branch": "dev",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-crosswalk-modea-dep-align",
   "sourceHash": "0288c2caaeed0cbffe1b7cfe1bf89c0b8fa35858677f95613bfc6c5146d46384",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_us_ny_dfs_2023/package.json
+++ b/package/scf/scf/2025_2_1_us_ny_dfs_2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_us_ny_dfs_2023",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for us_ny_dfs_2023_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@zerobias-org/framework-us_ny-dfs-2023": "latest"
+    "@auditlogic/framework-us_ny-dfs-2023": "latest"
   }
 }


### PR DESCRIPTION
Repoints the 4 Mode-A SCF crosswalks' partner-framework dependency from the deprecated `@zerobias-org` mirror to the canonical `@auditlogic` package, so npm-install/publish doesn't 404 once the org mirrors are hard-deleted (#218 step 2).

`sourceStandard` is **unchanged** (org & auditlogic share the identical code) — only the dependency moves. Patch bump 3.0.0→3.0.1, gates green with `@auditlogic` deps resolved.

- `@zerobias-org/framework-iec-60601-2021` → `@auditlogic/framework-iec-60601-2021`
- `@zerobias-org/framework-iso-42001-2023` → `@auditlogic/framework-iso-42001-2023`
- `@zerobias-org/framework-nist-csf-v2` → `@auditlogic/framework-nist-csf-v2`
- `@zerobias-org/framework-us_ny-dfs-2023` → `@auditlogic/framework-us_ny-dfs-2023`

⚠️ **Merge AFTER the DB duplicate-standard removal** — until the org duplicate standard rows are removed, `getByPackage` still sees 2 rows and these won't load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)