### PR TITLE
fix(scf): revert NIST crosswalks to @zerobias-org frameworks (undo #97)

### DIFF
--- a/package/scf/scf/2025_2_1_nist_800-171_rev2/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev2/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.0.1-uat.0",
-  "branch": "fix/scf-crosswalk-nist-code-align",
-  "sourceHash": "341660db54c7392531bb635fb210db3426c74f98673d86d819023b9c58e2f67f",
+  "version": "3.0.2-uat.0",
+  "branch": "fix/scf-nist-crosswalk-revert-to-zerobias-org",
+  "sourceHash": "53f888d05f786b93f420a0622b158179aebfade70aa8e0ba843c32890f1d3f5d",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/scf/scf/2025_2_1_nist_800-171_rev2/index.yml
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev2/index.yml
@@ -8,5 +8,5 @@ externalId: SP 800-171 - Protecting CUI in Nonfederal Systems and Organizations
   to Secure Controls Framework (SCF) 2025.2.1 Crosswalk
 code: nist_800-171_rev2_complianceforge_scf_2025_2_1_crosswalk
 status: active
-sourceStandard: nist.800171.rev2.framework
+sourceStandard: nist.800-171.rev2.framework
 targetStandard: scf.scf.2025_2_1.framework

--- a/package/scf/scf/2025_2_1_nist_800-171_rev2/package.json
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_nist_800-171_rev2",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Crosswalk for nist_800-171_rev2_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@auditlogic/framework-nist-800171-rev2": "latest"
+    "@zerobias-org/framework-nist-800-171-rev2": "latest"
   }
 }

--- a/package/scf/scf/2025_2_1_nist_800-171_rev3/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev3/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.0.1-uat.0",
-  "branch": "fix/scf-crosswalk-nist-code-align",
-  "sourceHash": "b5de1d5b9f8ab09f68eebed85a039e01990b02935a30d689d3a9e1410288795a",
+  "version": "3.0.2-uat.0",
+  "branch": "fix/scf-nist-crosswalk-revert-to-zerobias-org",
+  "sourceHash": "9faee26c9df203d58b720f94845a2127fefe1ddb3cd3745294979b8d7cea5a30",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/scf/scf/2025_2_1_nist_800-171_rev3/index.yml
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev3/index.yml
@@ -5,5 +5,5 @@ description: Crosswalk mappings from NIST SP 800-171 R3 to the Secure Controls
 externalId: NIST SP 800-171 R3 to Secure Controls Framework (SCF) 2025.2.1 Crosswalk
 code: nist_800-171_rev3_complianceforge_scf_2025_2_1_crosswalk
 status: active
-sourceStandard: nist.800171.rev3.framework
+sourceStandard: nist.800-171.rev3.framework
 targetStandard: scf.scf.2025_2_1.framework

--- a/package/scf/scf/2025_2_1_nist_800-171_rev3/package.json
+++ b/package/scf/scf/2025_2_1_nist_800-171_rev3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_nist_800-171_rev3",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Crosswalk for nist_800-171_rev3_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@auditlogic/framework-nist-800171-rev3": "latest"
+    "@zerobias-org/framework-nist-800-171-rev3": "latest"
   }
 }

--- a/package/scf/scf/2025_2_1_nist_800_218_v1_1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_nist_800_218_v1_1/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.0.1-uat.0",
-  "branch": "fix/scf-crosswalk-nist-code-align",
-  "sourceHash": "84227b053d4d61f47c9b5197c0adaf38c0b641051df213ad4f60c3a8599075e2",
+  "version": "3.0.2-uat.0",
+  "branch": "fix/scf-nist-crosswalk-revert-to-zerobias-org",
+  "sourceHash": "79df819a8d6f7581ca9eb4088400135f6c0b554968372b9044b560c6c33955ec",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/scf/scf/2025_2_1_nist_800_218_v1_1/index.yml
+++ b/package/scf/scf/2025_2_1_nist_800_218_v1_1/index.yml
@@ -8,5 +8,5 @@ externalId: "SP 800-218 - Secure Software Development Framework (SSDF) Version
   1.1: to Secure Controls Framework (SCF) 2025.2.1 Crosswalk"
 code: nist_800_218_v1_1_complianceforge_scf_2025_2_1_crosswalk
 status: active
-sourceStandard: nist.800218.v1_1.framework
+sourceStandard: nist.800_218.v1_1.framework
 targetStandard: scf.scf.2025_2_1.framework

--- a/package/scf/scf/2025_2_1_nist_800_218_v1_1/package.json
+++ b/package/scf/scf/2025_2_1_nist_800_218_v1_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_nist_800_218_v1_1",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Crosswalk for nist_800_218_v1_1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",
@@ -31,6 +31,6 @@
   ],
   "dependencies": {
     "@zerobias-org/framework-scf-scf-2025.2.1": "latest",
-    "@auditlogic/framework-nist-800218-v1.1": "latest"
+    "@zerobias-org/framework-nist-800_218-v1_1": "latest"
   }
 }


### PR DESCRIPTION
Reverts #97. The 3 NIST SCF crosswalks (`nist_800-171_rev2`, `nist_800-171_rev3`, `nist_800_218_v1_1`) are **open** content mapping **public standards**, so they must reference the **open `@zerobias-org`** framework — not the closed `@auditlogic` one #97 wrongly repointed them to.

### Why (decisive evidence)
The crosswalks' mapped NFO controls only exist in the `@zerobias-org` **dash-coded** framework (123 NFO). The `@auditlogic` **stripped-coded** copy has 62 → ~72 link targets couldn't resolve. So `@zerobias-org` is the correct framework.

### What this changes
Restores `sourceStandard` + partner dependency to `@zerobias-org` (dash codes), bumps 3.0.1 → 3.0.2, gates green.

| crosswalk | sourceStandard | dependency |
|---|---|---|
| nist_800-171_rev2 | `nist.800171.rev2` → `nist.800-171.rev2.framework` | `@auditlogic/...800171-rev2` → `@zerobias-org/framework-nist-800-171-rev2` |
| nist_800-171_rev3 | `nist.800171.rev3` → `nist.800-171.rev3.framework` | → `@zerobias-org/framework-nist-800-171-rev3` |
| nist_800_218_v1_1 | `nist.800218.v1_1` → `nist.800_218.v1_1.framework` | → `@zerobias-org/framework-nist-800_218-v1_1` |

### ⚠️ Merge dependency
The `@zerobias-org` partner frameworks are currently deprecated/retired in the env. This PR will publish but **won't load** until they're un-deprecated + active:

- **Blocked on `zerobias-org/framework` #223** (DRAFT) — restores + un-deprecates the 7 `@zerobias-org` frameworks (reverses #218/#219; needs Kevin sign-off). Merge #223 → publish → load **first**, then merge this.
- DB cleanup (separate ticket): remove the duplicate `@auditlogic` standards + the stale `complianceforge` predecessor crosswalks so resolution is unambiguous and these load fresh.

### Related
- Supersedes #97 (wrong direction, already merged)
- #98 closed/abandoned — the 4 Mode-A crosswalks already correctly depend on `@zerobias-org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)