### PR TITLE
chore(scf): republish 9 missed SCF crosswalks to trigger load

### DIFF
--- a/package/scf/scf/2025_2_1_au_aee_v1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_au_aee_v1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "5d3df2c8bf7b4270ec1b907ad87bf272ea6f1982abf16ae4e8f5725437a6f06e",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_au_aee_v1/package.json
+++ b/package/scf/scf/2025_2_1_au_aee_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_au_aee_v1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for au_aee_v1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_au_ism_v1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_au_ism_v1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "59400119aad1cfcb7a27667a4c2b4a57f64405ce200dcb34993b1d10937eb02b",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_au_ism_v1/package.json
+++ b/package/scf/scf/2025_2_1_au_ism_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_au_ism_v1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for au_ism_v1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_ca_osfi_v1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_ca_osfi_v1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "9b932dcdc4edbec15e45503e7281de28d6e519246f9cfffedc5daf93243cb771",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_ca_osfi_v1/package.json
+++ b/package/scf/scf/2025_2_1_ca_osfi_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_ca_osfi_v1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for ca_osfi_v1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_ca_pci_v10_171/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_ca_pci_v10_171/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "94e49cc181fa617280be7a44138571aa89e15d44a2018886767f8d72094336b6",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_ca_pci_v10_171/package.json
+++ b/package/scf/scf/2025_2_1_ca_pci_v10_171/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_ca_pci_v10_171",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for ca_pci_v10_171_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_cis_csc_v8_1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_cis_csc_v8_1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "5f371cfbc7bfd0afc0f0765c72ef26b1114e6fb4d4dcaa184d24099312235620",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_cis_csc_v8_1/package.json
+++ b/package/scf/scf/2025_2_1_cis_csc_v8_1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_cis_csc_v8_1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for cis_csc_v8_1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_cisa_ssdaf_v1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_cisa_ssdaf_v1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "87707f06629da639762ce73b9a92f10c60a54e4d6c036370da65ae85960164b3",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_cisa_ssdaf_v1/package.json
+++ b/package/scf/scf/2025_2_1_cisa_ssdaf_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_cisa_ssdaf_v1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for cisa_ssdaf_v1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_cisa_tic_v3/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_cisa_tic_v3/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "f831b672545e4ae099b6d2ebfcebcd53a6f07efb98f6587b5ce256b4bc5f0674",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_cisa_tic_v3/package.json
+++ b/package/scf/scf/2025_2_1_cisa_tic_v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_cisa_tic_v3",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for cisa_tic_v3_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_cn_csl_v1/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_cn_csl_v1/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "1ad020ac4377a4229a4a2c25a2c9d27e362c3a4a86056eb99e61f472b06b254f",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_cn_csl_v1/package.json
+++ b/package/scf/scf/2025_2_1_cn_csl_v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_cn_csl_v1",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for cn_csl_v1_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",

--- a/package/scf/scf/2025_2_1_es_boe_v2022/gate-stamp.json
+++ b/package/scf/scf/2025_2_1_es_boe_v2022/gate-stamp.json
@@ -1,6 +1,6 @@
 {
-  "version": "3.0.0-uat.0",
-  "branch": "feat/scf-vendor-migration",
+  "version": "3.0.1-uat.0",
+  "branch": "fix/scf-load-9-missed-crosswalks",
   "sourceHash": "09af0cf754d36bea76033c380256abee7d1e4c97b029ddde5b145348504bc7ed",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {

--- a/package/scf/scf/2025_2_1_es_boe_v2022/package.json
+++ b/package/scf/scf/2025_2_1_es_boe_v2022/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/crosswalk-scf-scf-2025_2_1_es_boe_v2022",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Crosswalk for es_boe_v2022_complianceforge_scf_2025_2_1_crosswalk",
   "author": "team@zerobias.com",
   "license": "ISC",


### PR DESCRIPTION
9 SCF crosswalks were published in the original migration but their env load was never processed — no scf-scf artifact exists in dev, and their dev dist-tag is stuck at `3.0.0-qa.0` (#95/#96 never touched them, so no fresh load event fired).

Their content is already correct: they depend on `@zerobias-org` frameworks (single-row, resolving) with a single complianceforge predecessor → a fresh publish triggers a clean `migrates-from` re-parent.

**No-op bump 3.0.0 → 3.0.1** (+ regenerated gate-stamps) to fire the dev publish event. No content/dep changes.

Packages: au_aee, au_ism, ca_osfi, ca_pci, cis_csc, cisa_ssdaf, cisa_tic, cn_csl, es_boe.

`nist_800-53_v5` is **excluded** — it has a duplicate complianceforge predecessor (2 rows) that needs a DB dedup first (separate handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)