### PR TITLE
docs: add SCF attribution notice (CC BY-ND 4.0)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,43 @@
+# Content Attribution Notices
+
+The crosswalk packages in this repository reproduce mapping data whose source
+material is owned by third parties and used under their published licenses.
+This file records the attribution those licenses require. It travels with the
+repository; the same notices apply to the npm packages published from it.
+
+The `"license"` field in each package's `package.json` describes the packaging
+and build scaffolding, not the mapped content. The content licenses below
+govern the substantive mapping data.
+
+---
+
+## Secure Controls Framework (SCF)
+
+**Applies to:** every package under `package/scf/scf/`.
+
+These crosswalks reproduce control-mapping relations — focal-document element
+ID ↔ SCF control ID pairs, the Set Theory Relationship Mapping (STRM)
+relationship type, and the strength-of-relationship value — from the
+**Secure Controls Framework (SCF)** published by the
+Secure Controls Framework Council, LLC.
+
+- **Source:** [Secure Controls Framework](https://securecontrolsframework.com/) —
+  STRM mappings as distributed via the
+  [official SCF spreadsheet](https://github.com/securecontrolsframework/securecontrolsframework)
+  and the [published STRM documents](https://securecontrolsframework.com/set-theory-relationship-mapping-strm/)
+- **Copyright:** © Secure Controls Framework Council, LLC
+- **License:** [Creative Commons Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)](https://creativecommons.org/licenses/by-nd/4.0/)
+- **Changes:** the mapping data has been converted from the officially
+  distributed spreadsheet format into YAML for machine consumption. The
+  mapping content itself — element pairs, relationship types, and strength
+  values — is reproduced verbatim and unmodified. No mappings have been
+  added, removed, edited, or re-scored.
+
+SCF controls are used in this solution. This repository and the ZeroBias
+platform are not endorsed by, affiliated with, or sponsored by the Secure
+Controls Framework Council, LLC.
+
+Per the CC BY-ND 4.0 license, this content may be redistributed verbatim with
+this attribution, but modified or derivative versions of the SCF mapping data
+may not be distributed. Do not edit the mapping content of these packages;
+regenerate them from the officially published SCF sources instead.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ZeroBias crosswalk artifacts — element-to-element mappings between two compliance frameworks. Each `package/<vendor>/<suite>/<versionPair>/` directory is one publishable crosswalk (e.g. `aiuc/aiuc_1/v1_csa_aicm_v1` maps AIUC-1 v1 ✕ CSA AICM v1).
 
+## Content licensing & attribution
+
+Mapping data reproduced from third-party sources is used under those sources' published licenses — see **[NOTICE.md](NOTICE.md)** for the required attributions. In particular, the SCF crosswalks (`package/scf/scf/*`) reproduce [CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/) STRM mapping data: redistribute verbatim with attribution; never distribute modified mapping data. The `"license"` field in each `package.json` covers packaging/scaffolding only, not the mapped content.
+
 ## Authentication
 
 Set `ZB_TOKEN` in your environment to authenticate with the npm registry. Get one from [ZeroBias](https://app.zerobias.com).


### PR DESCRIPTION
## Why

The 46 `package/scf/scf/*` crosswalks reproduce SCF STRM mapping data — focal-document ↔ SCF control ID pairs, STRM relationship types, and strength values. Licensing re-review (2026-07-09) confirmed all SCF content including the STRM mappings is distributed under **CC BY-ND 4.0** (verified against [SCF T&C](https://securecontrolsframework.com/terms-conditions/), the [official GitHub distribution](https://github.com/securecontrolsframework/securecontrolsframework), and the free published [STRM documents](https://securecontrolsframework.com/set-theory-relationship-mapping-strm/) — which carry no on-document restriction and reproduce *more* than these packages do, including full control descriptions). Verbatim redistribution, including commercial, is expressly permitted — **but the BY clause requires attribution** (credit + license link + statement of changes), which the repo did not carry until now. SCF's own guidance blesses exactly our use case: *"attribution is as simple as stating SCF controls are used in the solution, such as a GRC platform that includes SCF content."*

## What

- **NOTICE.md** — required SCF attribution: source, copyright, CC BY-ND 4.0 link, changes statement (spreadsheet→YAML format shift, mapping content verbatim/unmodified), no-endorsement disclaimer, and a warning to never distribute *modified* mapping data (ND clause).
- **README.md** — short "Content licensing & attribution" section pointing at NOTICE.md.

## Deliberately out of scope

- Per-package `license` metadata fix (currently misstated as `ISC`): editing 46 `package.json` files would invalidate every committed gate stamp and force a mass republish. It rides along with each package's next content bump instead.
- Attribution for non-SCF sources (OpenCRE, etc.) — NOTICE.md is structured so those can be appended as follow-ups.

No package directories touched → no publishes triggered.

Unblocks #105 / #106 (CMMC & FedRAMP → SCF), which were gated on the SCF licensing decision.