### PR TITLE
fix(opencre)!: repoint OWASP crosswalk deps to @zerobias-org

### DIFF
--- a/package/opencre/opencre/v1_owasp_asvs_v4_0_3/gate-stamp.json
+++ b/package/opencre/opencre/v1_owasp_asvs_v4_0_3/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "2.0.1-uat.0",
+  "branch": "fix/opencre-owasp-repoint-public-deps",
+  "sourceHash": "a7db4cc39b6a4decba7dec4a1cb6ca7d6ca9ad072dd6df8311cc5655c0b05cbd",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/opencre/opencre/v1_owasp_asvs_v4_0_3/package.json
+++ b/package/opencre/opencre/v1_owasp_asvs_v4_0_3/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@zerobias-org/crosswalk-opencre-opencre-v1_owasp_asvs_v4_0_3",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenCRE v1 OWASP ASVS v4.0.3 Crosswalk",
   "author": "team@zerobias.com",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "package": "opencre.opencre.v1_owasp_asvs_v4_0_3.crosswalk"
   },
   "dependencies": {
-    "@auditlogic/framework-owasp-asvs-v4.0.3": "latest",
+    "@zerobias-org/framework-owasp-asvs-v4.0.3": "latest",
     "@zerobias-org/framework-opencre-opencre-v1": "latest",
     "@zerobias-org/suite-opencre-opencre": "latest"
   }

--- a/package/opencre/opencre/v1_owasp_samm_v1_0/gate-stamp.json
+++ b/package/opencre/opencre/v1_owasp_samm_v1_0/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "2.0.1-uat.0",
+  "branch": "fix/opencre-owasp-repoint-public-deps",
+  "sourceHash": "365a72bdc8232e03d84ab8bc0342c168e8bcbdf6a76afc8c421d2b849bdf5515",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/opencre/opencre/v1_owasp_samm_v1_0/package.json
+++ b/package/opencre/opencre/v1_owasp_samm_v1_0/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@zerobias-org/crosswalk-opencre-opencre-v1_owasp_samm_v1_0",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenCRE v1 OWASP SAMM v1.0 Crosswalk",
   "author": "team@zerobias.com",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "package": "opencre.opencre.v1_owasp_samm_v1_0.crosswalk"
   },
   "dependencies": {
-    "@auditlogic/framework-owasp-samm-v1.0": "latest",
+    "@zerobias-org/framework-owasp-samm-v1.0": "latest",
     "@zerobias-org/framework-opencre-opencre-v1": "latest",
     "@zerobias-org/suite-opencre-opencre": "latest"
   }

--- a/package/opencre/opencre/v1_owasp_wstg_v5/gate-stamp.json
+++ b/package/opencre/opencre/v1_owasp_wstg_v5/gate-stamp.json
@@ -1,7 +1,7 @@
 {
-  "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "version": "2.0.1-uat.0",
+  "branch": "fix/opencre-owasp-repoint-public-deps",
+  "sourceHash": "ad100f9b7fee64bb51cb6d9ce5c30acbd57236d683940a422f636d009ea78323",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/opencre/opencre/v1_owasp_wstg_v5/package.json
+++ b/package/opencre/opencre/v1_owasp_wstg_v5/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@zerobias-org/crosswalk-opencre-opencre-v1_owasp_wstg_v5",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenCRE v1 to OWASP WSTG v5 Crosswalk",
   "author": "team@zerobias.com",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "type": "module",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "package": "opencre.opencre.v1_owasp_wstg_v5.crosswalk"
   },
   "dependencies": {
-    "@auditlogic/benchmark-owasp-wstg-v5": "latest",
+    "@zerobias-org/benchmark-owasp-wstg-v5": "latest",
     "@zerobias-org/framework-opencre-opencre-v1": "latest",
     "@zerobias-org/suite-opencre-opencre": "latest"
   }


### PR DESCRIPTION
## Why (licensing review step 5)

The OWASP content these crosswalks map is now published publicly (zerobias-org/framework#230: asvs+samm @3.0.0; zerobias-org/benchmark#5: wstg @2.0.0). These 3 were the **last public crosswalks depending on the private `@auditlogic` registry** for OWASP content.

## What (all → patch bump 2.0.1)

- `opencre/opencre/v1_owasp_asvs_v4_0_3`: dep → `@zerobias-org/framework-owasp-asvs-v4.0.3`
- `opencre/opencre/v1_owasp_samm_v1_0`: dep → `@zerobias-org/framework-owasp-samm-v1.0`
- `opencre/opencre/v1_owasp_wstg_v5`: dep → `@zerobias-org/benchmark-owasp-wstg-v5`
- `license`: ISC → `CC0-1.0` (OpenCRE mapping data, matching the relocated opencre siblings)
- Same artifact codes (`sourceStandard`/`targetStandard` unchanged — the frameworks kept their `zerobias.package` codes in the scope move)
- Gates green — full dataloader loads (2.0.39)

## Remaining @auditlogic deps in this repo after this merges

Only the 5 NIST ones (3× `nist/800-218` + 2 opencre) — being consolidated onto the existing public NIST variants (option B) as the final step-5 batch.