### PR TITLE
docs(skill): fix @auditlogic registry URL

### DIFF
--- a/.claude/skills/create-crosswalk.md
+++ b/.claude/skills/create-crosswalk.md
@@ -254,7 +254,7 @@ package/{sourceVendor}/{sourceSuite}/{sourceVersion}_{target}/
     "validate": "tsx ../../../../scripts/validate.ts"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "registry": "https://pkg.zerobias.org/"
   },
   "files": [
     "index.yml",
@@ -311,10 +311,9 @@ package/{sourceVendor}/{sourceSuite}/{sourceVersion}_{target}/
 //pkg.zerobias.org/:_authToken=${ZB_TOKEN}
 ```
 
-**If package depends on @auditlogic packages, also add:**
+**If package depends on @auditlogic packages, also add the scope (same registry):**
 ```
-@auditlogic:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+@auditlogic:registry=https://pkg.zerobias.org/
 @zerobias-org:registry=https://pkg.zerobias.org/
 //pkg.zerobias.org/:_authToken=${ZB_TOKEN}
 ```


### PR DESCRIPTION
The `create-crosswalk` skill's .npmrc and publishConfig examples pointed at `npm.pkg.github.com` (private GitHub Packages). Both `@auditlogic` and `@zerobias-org` scopes are served from `pkg.zerobias.org` with `ZB_TOKEN` — examples now match the rest of the org's docs.

Heads-up: `update_auditmation_packages.sh` on the `feat/scf-2025-2026-version-crosswalk` branch hardcodes a developer's home directory — worth fixing on that branch before merge.